### PR TITLE
Delete change auth_source after command connect.

### DIFF
--- a/app/controllers/redmine_telegram_connections_controller.rb
+++ b/app/controllers/redmine_telegram_connections_controller.rb
@@ -20,8 +20,6 @@ class RedmineTelegramConnectionsController < ApplicationController
 
     @telegram_account.user = @user
     @telegram_account.save
-
-    set_telegram_auth_source if Redmine::Plugin.installed?('redmine_2fa')
   end
 
   def notice
@@ -30,10 +28,5 @@ class RedmineTelegramConnectionsController < ApplicationController
     else
       t('telegram_common.redmine_telegram_connections.create.error')
     end
-  end
-
-  def set_telegram_auth_source
-    @user.auth_source = ::Redmine2FA::AuthSource::Telegram.first
-    @user.save
   end
 end


### PR DESCRIPTION
Причины: если у пользователя установлен режим аутентификации отличный от Telegram для плагина redmine_2fa, то выполнение команды /connect для любого другого плагина приведет к блокировке аккаунта, т.к. коды подтверждения будут отправляться в несуществующий чат с ботом 2FA. 